### PR TITLE
simple elm scaffolding using node to serve it up

### DIFF
--- a/elm-example/Dockerfile
+++ b/elm-example/Dockerfile
@@ -1,0 +1,7 @@
+FROM npm
+EXPOSE 80
+RUN npm install -g elm
+ADD . /app
+WORKDIR /app
+RUN elm make Main.elm --output Index.html
+ENTRYPOINT node server.js

--- a/elm-example/Main.elm
+++ b/elm-example/Main.elm
@@ -1,0 +1,37 @@
+module Main exposing (main)
+
+import Html as Html exposing (Html)
+
+
+main : Program Never Model Msg
+main =
+    Html.program
+        { init = init
+        , subscriptions = always Sub.none
+        , update = update
+        , view = view
+        }
+
+
+init : ( Model, Cmd Msg )
+init =
+    Model () ! []
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    model ! []
+
+
+view : Model -> Html Msg
+view model =
+    Html.h1 [] [ Html.text "Elm on Dropstack!" ]
+
+
+type alias Model =
+    { empty : ()
+    }
+
+
+type Msg
+    = NoOp

--- a/elm-example/README.md
+++ b/elm-example/README.md
@@ -1,0 +1,1 @@
+# Serve a simple Elm app (using node.js)

--- a/elm-example/elm-package.json
+++ b/elm-example/elm-package.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0.0",
+    "summary": "helpful summary of your project, less than 80 characters",
+    "repository": "https://github.com/user/project.git",
+    "license": "BSD3",
+    "source-directories": [
+        "."
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "elm-lang/core": "5.1.1 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
+    },
+    "elm-version": "0.18.0 <= v < 0.19.0"
+}

--- a/elm-example/server.js
+++ b/elm-example/server.js
@@ -1,0 +1,12 @@
+PORT = 80;
+HOST = '127.0.0.1';
+
+var fs = require('fs'),
+http = require('http');
+
+
+http.createServer(function(request, response) {
+    fs.createReadStream('Index.html', {
+        'bufferSize': 4*1024
+    }).pipe(response);
+}).listen(PORT, HOST);;


### PR DESCRIPTION
if I have this in an folder and npm/node installed everything should work by

    npm install -g elm
    elm make Main.elm --output Index.html
    node server.js

what is surely wrong is the `FROM npm` image ... to be honest: I have no clue what the right one might be

Also I just use `elm make` to generate a HTML - it would probably be a better example to have a static `index.html` that just links a generated elm js-script.

I'll update the example once it's clear that this is indeed something you can use / is of interest