### PR TITLE
added example for dotnetcore 2 + F# + suave

### DIFF
--- a/dotnet-core2-fsharp-suave/.gitignore
+++ b/dotnet-core2-fsharp-suave/.gitignore
@@ -1,0 +1,3 @@
+bin/*
+obj/*
+*.lock.json

--- a/dotnet-core2-fsharp-suave/Dockerfile
+++ b/dotnet-core2-fsharp-suave/Dockerfile
@@ -1,0 +1,7 @@
+FROM microsoft/dotnet:2-sdk
+WORKDIR /src
+ADD . .
+EXPOSE 80
+RUN dotnet restore
+RUN dotnet build
+ENTRYPOINT dotnet run 0.0.0.0 80

--- a/dotnet-core2-fsharp-suave/Program.fs
+++ b/dotnet-core2-fsharp-suave/Program.fs
@@ -1,0 +1,40 @@
+﻿open Suave  
+open System.Net
+
+[<EntryPoint>]
+let main argv = 
+
+    let parsePort s =
+        match System.UInt16.TryParse s with
+        | (true, port) -> port
+        | _ -> 8083us
+
+    let parseIp s =
+        match IPAddress.TryParse s with
+        | (true, ip) -> ip
+        | _ -> IPAddress.Loopback    
+
+    let (ip, port) =
+        match argv.Length with
+        | 1 ->
+            (IPAddress.Loopback, parsePort argv.[0])
+        | n when n >= 2 ->        
+            (parseIp argv.[0], parsePort argv.[1])
+        | _ -> (IPAddress.Loopback, 8083us)        
+
+    // start suave
+    startWebServer
+        { defaultConfig with
+            bindings = 
+                [ 
+                    HttpBinding.create 
+                        HTTP ip
+                        port 
+                ] 
+        }
+        (   
+            "<h1>F#/Suave loves Dropstack!</h1>"
+            |> Successful.OK
+        )        
+
+    0

--- a/dotnet-core2-fsharp-suave/README.md
+++ b/dotnet-core2-fsharp-suave/README.md
@@ -1,0 +1,27 @@
+# DotNet Core 1.1 (F# + Suave) example
+
+**Docker + F# / Suave Live Example**
+
+## Run
+
+```bash
+dotnet restore
+dotnet run
+```
+
+```bash
+curl -s http://localhost:8083
+```
+
+## Deploy via [https://dropstack.run](https://dropstack.run)
+
+```bash
+dropstack deploy
+```
+
+## Docker
+
+```bash
+docker build -t dotnet-core2-fsharp-suave .
+docker run -it -p 8083:80 dotnet-core2-fsharp-suave
+```

--- a/dotnet-core2-fsharp-suave/suaveExample.fsproj
+++ b/dotnet-core2-fsharp-suave/suaveExample.fsproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Suave" Version="2.1.1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Hi Mike,

please have a look at this.

This should demonstrate the usage of F# with dotnetcore-2 - the existing demo uses the older `.json` project file which is IMO not supported any more

With this it should be easier to find that it's about F# anyway (`.fsproj`)

It's running locally but sadly I cannot test it on dropstack at the moment as it seems the disk is full on your server:

    ⣇ Deploying [3.65s]
    An unexpected error occurred!
    Message: error: ENOSPC: no space left on device, open '/app/dotnet-core2-fsharp-suave.tar'

Cheers,
Carsten
